### PR TITLE
Fix Hide Recommended ui bug when switching to another page.

### DIFF
--- a/content.js
+++ b/content.js
@@ -1588,6 +1588,8 @@ function ensureTranscriptPanelVisible() {
 
 // Unhide transcript/engagement panels and their ancestor containers
 function restoreTranscriptVisibility() {
+  //only run this function on video pages
+  if (!window.location.pathname.includes('/watch?')) return;
   const panels = document.querySelectorAll('ytd-engagement-panel-section-list-renderer, ytd-transcript-segment-list-renderer');
   panels.forEach(panel => {
     panel.style.display = '';


### PR DESCRIPTION
Issue:  when Hide Recommended is toggled, the video would persist when switching back to another page(i.e. the home page or a search page)

Cause: restoreTranscriptVisibility() recursively unhides all the parent elements of the youtube engagement panels and transcript panels.  But these panels and the video player still persist when switching to another page, leading to the unintended behavior of the video showing up on the main page.

Fix:  have restoreTranscriptVisibility() only run in youtube.com/watch?... pages.  

[Video of bug](https://drive.google.com/file/d/1ePmlSn5z7WF09cmFTbmci13jowv485As/view?usp=sharing)
[Video after fix](https://drive.google.com/file/d/1L3S1_T1PK7TLmenxuZHY-FqYWzXyBJjI/view?usp=sharing)